### PR TITLE
fix: JSONキャッシュを無効化しデータ更新を即時反映

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,10 @@
-<Files ~ "\.(html|css|xml|js|json)$">
-Header set Pragma no-cache
-Header set Cache-Control no-cache
+<Files ~ "\.json$">
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+    Header set Pragma "no-cache"
+    Header set Expires "0"
+</Files>
+
+<Files ~ "\.(html|css|js)$">
+    Header set Cache-Control "no-cache"
+    Header set Pragma "no-cache"
 </Files>

--- a/impl/cedec.js
+++ b/impl/cedec.js
@@ -127,6 +127,7 @@ var CEDEC = (function($){
 		$.ajax({
 			type: 'GET',
 			url: url,
+			cache: false,
 			dataType: 'json',
 			success: function(option) {
 				return function(data){


### PR DESCRIPTION
## Summary

数日おきにJSONデータを更新する運用に対応するため、ブラウザキャッシュを無効化。

- **cedec.js**: `schedule.json` の Ajax リクエストに `cache: false` を追加
  - jQueryが自動で `?_=timestamp` を付与し全環境（Go Live含む）でキャッシュを回避
- **.htaccess**: JSONファイルに強化されたキャッシュ無効化ヘッダーを設定
  - `no-store, no-cache, must-revalidate, max-age=0` で Apache環境でも強制再取得
  - HTML/CSS/JS は従来の `no-cache` を維持

なお `cedil.js` の `readJsonData` は既に `$.ajaxSetup({ cache: false })` が設定済みのため変更不要。

## Test plan

- [ ] スケジュールページ表示後、JSONを更新してリロードすると新しいデータが反映されること
- [ ] DevTools の Network タブで `schedule.json` のリクエストURLに `?_=` が付いていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)