### PR TITLE
fix: CEDiLリンク置換時に「ほかN名」クリックが効かなくなる不具合を修正

### DIFF
--- a/impl/cedec.js
+++ b/impl/cedec.js
@@ -246,7 +246,7 @@ var CEDEC = (function($){
 		}
 
 		// 資料公開（CEDiLリンク置換のターゲット）
-		$div.append(' 資料公開: 不明');
+		$('<span class="cedil-status"/>').text(' 資料公開: 不明').appendTo( $div );
 
 		return $div;
 	}

--- a/impl/index.js
+++ b/impl/index.js
@@ -1024,12 +1024,10 @@
 						}
 						if( title.indexOf( list[i].title ) == -1 ) continue;
 
-						// 「資料公開: 予定あり」「資料公開: 予定なし」を置換する
-						$this.html( $this.html().replace(
-											new RegExp('(資料公開: )(.*)(<\/div>)','g'),
-											'$1<a href="' + list[i].url +'#breadcrumbs" target="blank">公開済み</a>$3'
-										)
-									);
+						// 「資料公開: 不明」を「公開済み」リンクに置換する
+						$this.find('.cedil-status').html(
+							'資料公開: <a href="' + list[i].url + '#breadcrumbs" target="blank">公開済み</a>'
+						);
 						break;
 					}
 				}else if( m_year >= 2018) {

--- a/index.html
+++ b/index.html
@@ -59,9 +59,9 @@
 		<div id="contents_footer"></div>
 	</div>
 
-	<script src="impl/custom.js?v=202605062118"></script>
-	<script src="impl/cedec.js?v=202605062118"></script>
-	<script src="impl/cedil.js?v=202605062118"></script>
-	<script src="impl/index.js?v=202605062118"></script>
+	<script src="impl/custom.js"></script>
+	<script src="impl/cedec.js"></script>
+	<script src="impl/cedil.js"></script>
+	<script src="impl/index.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -59,9 +59,9 @@
 		<div id="contents_footer"></div>
 	</div>
 
-	<script src="impl/custom.js"></script>
-	<script src="impl/cedec.js"></script>
-	<script src="impl/cedil.js"></script>
-	<script src="impl/index.js"></script>
+	<script src="impl/custom.js?v=202605062118"></script>
+	<script src="impl/cedec.js?v=202605062118"></script>
+	<script src="impl/cedil.js?v=202605062118"></script>
+	<script src="impl/index.js?v=202605062118"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- CEDiL 資料が公開済みになったセッションで「ほか N 名」をクリックしても登壇者が展開されない不具合を修正
- `impl/cedec.js`: 「資料公開」テキストを `<span class="cedil-status">` で包むよう変更
- `impl/index.js`: `$this.html()` による DOM 全体の再構築をやめ、`.cedil-status` span のみを書き換えるよう変更

## Root Cause

`appendLinkToCEDiL` 内で `$this.html( $this.html().replace(...) )` を呼んでいた。  
`$this.html(newHtml)` は DOM を文字列から再構築するため、jQuery の `.click()` で登録した  
「ほか N 名」展開ハンドラがすべて破棄されていた。

## Test plan

- [x] CEDiL 資料公開済みのセッションで「ほか N 名」をクリックすると登壇者が展開されること
- [x] 「資料公開: 公開済み」リンクが表示され、クリックで CEDiL ページに遷移すること
- [x] CEDiL 未登録セッションは「資料公開: 不明」のまま表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)