### PR TITLE
refactor: cedil.js の未使用コード削除とキャッシュ追加

### DIFF
--- a/impl/cedil.js
+++ b/impl/cedil.js
@@ -6,214 +6,37 @@ var CEDiL = (function($){
 	//==========================================================================
 	// 定義
 	//==========================================================================
-	var MASTER_URL = "https://cedil.cesa.or.jp/";
-	var READ_URL   = MASTER_URL + "cedil_sessions/search_tag/";
-
-	var m_list = {};
-	var m_dataCash = {};
+	var m_jsonCache = {};
 
 	return {
-		
-		readData : readData					// 直接 クロスドメインで読み込んで結果を得る
-
-		,readJsonData : readJsonData		// サーバーに保存したJSONファイルを読み込む
-		,writeJsonData	: writeJsonData		// サーバーにJSONファイルを保存する
+		readJsonData : readJsonData		// サーバーに保存したJSONファイルを読み込む
 	};
 
 
 	//--------------------------------------------------------------------------
-	// 直接 クロスドメインで読み込んで結果を得る
-	// ※ページが無くなるまで再起的に読み続け、ページ読み込完了毎に success を呼び出す
 	//
-	// param	tag			CEDiLの検索用タグID
-	// param	success		ページ読み成功時のコールバック
-	// param	page		読み込むページ番号
-	// param	end			全てのページを読み終えた際のコールバック
 	//--------------------------------------------------------------------------
-	function readData( tag, success, page, end ){
-		if( tag === undefined )	return;
-		readPage(tag,success,page,end);
-	}
-
-	//--------------------------------------------------------------------------
-	// param	tag			CEDiLの検索用タグID
-	// param	success		ページ読み成功時のコールバック
-	// param	page		読み込むページ番号
-	// param	end			全てのページを読み終えた際のコールバック
-	//--------------------------------------------------------------------------
-	function readPage(tag,success,page,end){
-
-		if( page === undefined )	page = 1;
-		page = parseInt(page);
-
-		var cash_id = tag + "_" + page;
-		if( m_dataCash[cash_id] !== undefined ){
-			read_impl(tag,success,page);
+	function readJsonData( year, success ){
+		if( m_jsonCache[year] !== undefined ){
+			var cached = m_jsonCache[year];
+			if( cached.list.length > 0 && success != undefined ){
+				success( cached.list, cached.update_date );
+			}
 			return;
 		}
 
-		var url = READ_URL + tag + "/page:" + page;
-
-		$.ajax({
-			type: 'GET',
-			url: url + "?t=" + new Date().getTime(),
-		    beforeSend : function( xhr ){
-		        xhr.setRequestHeader("If-Modified-Since", "Thu, 01 Jun 1970 00:00:00 GMT");
-		    },
-			dataType: 'html',
-			success: (function(tag,success,page){
-				return function(html) {
-					var cash_id = tag + "_" + page;
-					if( m_dataCash[cash_id] === undefined ){
-						if( html.responseText !== undefined ){
-							m_dataCash[cash_id] = $(html.responseText);
-						}else{
-							m_dataCash[cash_id] = $(html);
-						}
-					}
-					read_impl(tag,success,page,end);
-				};
-			})(tag,success,page,end),
-			error:function(html){
-				alert("CEDiLのページが読み込めませんでした");
-			}
-		});
-
-		function read_impl(tag,success,page,end){
-
-			var $content = m_dataCash[cash_id].find('#content');
-			var list = getList( $content );
-
-			if( list.length > 0 && success != undefined ){
-				success( list );
-			}
-
-			if( m_list[tag] === undefined ){
-				m_list[tag] = [];
-			}
-			Array.prototype.push.apply( m_list[tag], list );
-
-			$content
-				.find('div.page_change')
-					.children(':eq(1)')
-						.children().each(function(){
-							if( $(this).text() != page ) return;
-
-							var $next = $(this).next();
-							if( $next.length ){
-								readPage(tag,success, $next.text(), end );
-							}else{
-								if( end != undefined ){
-									end( m_list[tag] );
-								}
-							}
-						});
-		}
-	}
-
-	//--------------------------------------------------------------------------
-	//
-	//--------------------------------------------------------------------------
-	function getList( $content ){
-
-		var list = [];
-		var $session_detail_list = $content.find(".session_detail_list");
-
-		$session_detail_list.find('h2').each(function(){
-			var $this = $(this);
-			var obj = {};
-
-			// 加工はしたくないがHTMLによってスペース有り無しがあったため
-			// スペース削除
-			obj.title = $this.text()
-							.replace(/\n/g, "")
-							.replace(/ /g, "")
-							.replace(/　/g, "");
-
-			// ex) https://cedil.cesa.or.jp/cedil_sessions/view/1464
-			obj.url  = MASTER_URL + "/cedil_sessions" + $this.find("a")[0].href.split("/cedil_sessions")[1];
-
-			// タイトルの重複が存在したため、日程だけ覚えておく
-			var date = $this.parent().find('.session_date').text();
-			if( date ){
-				var date_list = date.match(/\d{1,2}日/);
-				if( date_list.length ){
-					obj.date = date_list[0].replace('日','');
-				}
-			}
-
-			list.push( obj );
-		});
-
-		return list;
-	}
-
-	//--------------------------------------------------------------------------
-	//
-	//--------------------------------------------------------------------------
-	function readJsonData( year, tag, success ){
-		if( tag === undefined )	return;
-		
 		$.ajaxSetup({ cache: false });
 		$.getJSON('./web_data/' + year + "/cedil.json")
-			.done(function(year,tag,success){
+			.done(function(year, success){
 				return function(data){
 					if( data.list.length > 0 && success != undefined ){
-						success( data.list,  data.update_date );
+						m_jsonCache[year] = { list: data.list, update_date: data.update_date };
+						success( data.list, data.update_date );
 					}
-					console.log('成功');
 				}
-			}(year,tag,success))
+			}(year, success))
 			.fail(function(){
-				console.log('失敗');
+				console.log('CEDiL JSON 読み込み失敗');
 			});
-	}
-
-	//--------------------------------------------------------------------------
-	//
-	//--------------------------------------------------------------------------
-	function writeJsonData( year, tag, success, end ){
-
-		readData( tag, success, undefined, function(year){
-			
-			return function( list ){
-				
-				// 書き込むJSONデータ
-				var write_data = {
-					year : year
-					,update_date : new Date()
-					,list : list
-				};
-
-				var json = JSON.stringify( write_data );
-
-				$.ajax({
-					type: "POST",
-					url: "./cgi/write_cedil_json.php", // 送信先のPHP
-					dataType: 'json',
-					contentType: 'application/json',
-					data:json
-				}).success(function(data, status, xhr) {
-					// 通信成功時の処理
-					console.log("success");
-					console.log("list ="+ data.list.length );
-					console.log("status ="+status);
-					console.log("xhr ="+xhr);
-					// Write時はcashをクリアする
-					m_dataCash = {};
-					if( end ) end(data.list);
-
-				}).error(function(xhr, status, error) {
-					// 通信失敗時の処理
-					console.log("error");
-				}).complete(function(xhr, status) {
-					// 通信完了時の処理
-					console.log("fin");
-				});
-
-			}
-		}(year,end));
-
-
 	}
 })(jQuery);

--- a/impl/index.js
+++ b/impl/index.js
@@ -131,8 +131,7 @@
 			success	: function(index,data){
 				$('#contents_loading_icon').remove();
 				appendTable( data, index );
-				CEDiL.readJsonData( m_setting.year, m_setting.cedil_tag_no, appendLinkToCEDiL );
-				//CEDiL.readData( m_setting.cedil_tag_no, appendLinkToCEDiL );
+				CEDiL.readJsonData( m_setting.year, appendLinkToCEDiL );
 			},
 			error: function(request, textStatus, errorThrown){
 				$('#contents_loading_icon').remove();


### PR DESCRIPTION
## Summary

- `readData` / `readPage` / `getList` / `writeJsonData` を削除（index.js から未使用）
- `MASTER_URL` / `READ_URL` / `m_list` / `m_dataCash` を削除（上記関数でのみ使用）
- `readJsonData` の `tag` 引数を削除（URL生成に不使用だった）
- `m_jsonCache` による年度単位キャッシュを追加。同年度内での Day 切り替え時に cedil.json を再取得しないよう改善

結果: cedil.js が 220行 → 42行（192行削除・14行追加）

## Test plan

- [x] Day1 → Day2 → Day3 → Day1 と切り替えて、cedil.json の通信が初回のみ発生することをネットワークタブで確認
- [x] CEDiL リンクが各セッションに正しく付与されることを確認
- [x] 別年度に切り替えた際、その年度の初回のみ cedil.json を取得することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)