### PR TITLE
fix: URLパラメータ year を SCHEDULE_SETTING の定義値のみに制限

### DIFF
--- a/impl/cedec.js
+++ b/impl/cedec.js
@@ -156,8 +156,17 @@ var CEDEC = (function($){
 		// DOM
 		appendNaviMenuTo		:	appendNaviMenuTo,
 
-		getFloorURL				:	getFloorURL
+		getFloorURL				:	getFloorURL,
+
+		isValidYear				:	isValidYear
 	};
+
+	function isValidYear( year ){
+		for( var i = 0 ; i < SCHEDULE_SETTING.length ; ++i ){
+			if( SCHEDULE_SETTING[i].year == year ) return true;
+		}
+		return false;
+	}
 
 
 

--- a/impl/index.js
+++ b/impl/index.js
@@ -30,7 +30,7 @@
 	var m_url_params = getURL_Params();
 	var m_year       = DEFAULT_YEAR;
 
-	if( m_url_params.year !== undefined )	m_year = m_url_params.year;
+	if( m_url_params.year !== undefined && CEDEC.isValidYear( m_url_params.year ) )	m_year = m_url_params.year;
 
 	var m_highlightInfo = {
 		enabled	: false,


### PR DESCRIPTION
## Summary

- `CEDEC.isValidYear()` を `cedec.js` に追加し、`SCHEDULE_SETTING` に存在する年度かどうかをホワイトリストで検証
- `index.js` の URL パラメータ読み込み時に `isValidYear()` でガード。未定義の値はデフォルト年度にフォールバック

## 背景

`?year=<img src=x onerror=alert(1)>` のような URL を渡すと、`m_year` が HTML 文字列として DOM に挿入され XSS が発生する可能性があった。数値範囲チェックではなく `SCHEDULE_SETTING` のホワイトリストで絞ることで、定義済み年度以外は一切受け付けない。

## Test plan

- [x] `?year=2024` で 2024 年のスケジュールが表示されること
- [x] `?year=<img src=x onerror=alert(1)>` でデフォルト年度が表示され、スクリプトが実行されないこと
- [x] `?year=9999` でデフォルト年度が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)