### PR TITLE
fix: 会期後のlive→youtube変換を基調講演・CEDEC Awardsのみに限定

### DIFF
--- a/cgi/generate_json.php
+++ b/cgi/generate_json.php
@@ -531,9 +531,13 @@ function postprocess_sessions($sessions, $live_map = array(), $youtube_map = arr
 
         if ($event_over && $live !== null) {
             if ($youtube === null) {
-                // 基調講演・CEDEC Awards等: YouTubeチャンネルに再投稿されないため
-                // live URLをyoutubeパラメータに変換して永続化する
-                $youtube = $live;
+                // 基調講演・CEDEC Awards等はYouTubeへ再投稿されないため live URL を永続化する
+                // 通常セッションはYouTube動画がない場合、live URLを破棄する
+                $is_archive_session = $s['category'] === '基調講演'
+                                   || stripos($s['title'], 'CEDEC AWARDS') !== false;
+                if ($is_archive_session) {
+                    $youtube = $live;
+                }
             }
             // 会期後はliveパラメータを削除
             $live = null;


### PR DESCRIPTION
## 背景

ライブ配信はあったが会期後にYouTube動画が公開されなかったセッションで、
live URLがyoutubeパラメータとして残ってしまう問題があった。

## 変更内容

`postprocess_sessions` 内のlive→youtube変換を、以下のセッションのみに限定する。

- `category === '基調講演'`
- タイトルに `'CEDEC AWARDS'` を含む（大文字小文字不問）

それ以外の通常セッションは、YouTube動画が見つからない場合 live URLを破棄する（`youtube` パラメータに変換しない）。

## Test plan

- [x] `php cgi/generate_json.php 2025` を実行し、基調講演セッションの `youtube` に live URLが設定されること
- [x] 通常セッションで YouTube動画が存在するものは引き続き `youtube` が設定されること
- [x] 通常セッションで YouTube動画が存在しないものは `youtube` が設定されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)